### PR TITLE
compareSet method for HashStore and FileStore

### DIFF
--- a/torch/lib/c10d/FileStore.cpp
+++ b/torch/lib/c10d/FileStore.cpp
@@ -298,6 +298,19 @@ void FileStore::set(const std::string& key, const std::vector<uint8_t>& value) {
   file.write(value);
 }
 
+std::vector<uint8_t> FileStore::compareSet(
+    const std::string& key,
+    const std::vector<uint8_t>& currentValue,
+    const std::vector<uint8_t>& newValue) {
+  if (get(key) == currentValue){
+    set(key, newValue);
+    return newValue;
+  }
+  else{
+    return get(key);
+  }
+}
+
 std::vector<uint8_t> FileStore::get(const std::string& key) {
   std::string regKey = regularPrefix_ + key;
   const auto start = std::chrono::steady_clock::now();

--- a/torch/lib/c10d/FileStore.hpp
+++ b/torch/lib/c10d/FileStore.hpp
@@ -17,6 +17,11 @@ class FileStore : public Store {
 
   void set(const std::string& key, const std::vector<uint8_t>& value) override;
 
+  std::vector<uint8_t> compareSet(
+      const std::string& key,
+      const std::vector<uint8_t>& currentValue,
+      const std::vector<uint8_t>& newValue) override;
+
   std::vector<uint8_t> get(const std::string& key) override;
 
   int64_t add(const std::string& key, int64_t value) override;

--- a/torch/lib/c10d/HashStore.cpp
+++ b/torch/lib/c10d/HashStore.cpp
@@ -18,6 +18,19 @@ void HashStore::set(const std::string& key, const std::vector<uint8_t>& data) {
   cv_.notify_all();
 }
 
+std::vector<uint8_t> HashStore::compareSet(
+    const std::string& key,
+    const std::vector<uint8_t>& currentValue,
+    const std::vector<uint8_t>& newValue) {
+  if (get(key) == currentValue){
+    set(key, newValue);
+    return newValue;
+  }
+  else{
+    return get(key);
+  }
+}
+
 std::vector<uint8_t> HashStore::get(const std::string& key) {
   std::unique_lock<std::mutex> lock(m_);
   auto it = map_.find(key);

--- a/torch/lib/c10d/HashStore.hpp
+++ b/torch/lib/c10d/HashStore.hpp
@@ -16,6 +16,11 @@ class HashStore : public Store {
 
   void set(const std::string& key, const std::vector<uint8_t>& data) override;
 
+  std::vector<uint8_t> compareSet(
+      const std::string& key,
+      const std::vector<uint8_t>& currentValue,
+      const std::vector<uint8_t>& newValue) override;
+
   std::vector<uint8_t> get(const std::string& key) override;
 
   void wait(const std::vector<std::string>& keys) override {

--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -337,7 +337,6 @@ void TCPStoreDaemon::closeStopSignal() {
 }
 
 void TCPStoreDaemon::stop() {
-  run();
   if (controlPipeFd_[1] != -1) {
     // close the write end of the pipe
     ::close(controlPipeFd_[1]);

--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -337,6 +337,7 @@ void TCPStoreDaemon::closeStopSignal() {
 }
 
 void TCPStoreDaemon::stop() {
+  run();
   if (controlPipeFd_[1] != -1) {
     // close the write end of the pipe
     ::close(controlPipeFd_[1]);

--- a/torch/lib/c10d/test/FileStoreTest.cpp
+++ b/torch/lib/c10d/test/FileStoreTest.cpp
@@ -51,6 +51,13 @@ void testGetSet(std::string path, std::string prefix = "") {
     c10d::test::check(store, "key2", "value2");
     auto numKeys = fileStore->getNumKeys();
     EXPECT_EQ(numKeys, 3);
+
+    // Check compareSet, does not check return value
+    c10d::test::compareSet(
+        store, "key0", "wrongCurrentValue", "newValue");
+    c10d::test::check(store, "key0", "value0");
+    c10d::test::compareSet(store, "key0", "value0", "newValue");
+    c10d::test::check(store, "key0", "newValue");
   }
 
   // Perform get on new instance
@@ -63,6 +70,7 @@ void testGetSet(std::string path, std::string prefix = "") {
     // other store above.
     EXPECT_EQ(numKeys, 4);
   }
+
 }
 
 void stressTestStore(std::string path, std::string prefix = "") {

--- a/torch/lib/c10d/test/FileStoreTest.cpp
+++ b/torch/lib/c10d/test/FileStoreTest.cpp
@@ -70,7 +70,6 @@ void testGetSet(std::string path, std::string prefix = "") {
     // other store above.
     EXPECT_EQ(numKeys, 4);
   }
-
 }
 
 void stressTestStore(std::string path, std::string prefix = "") {

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -19,6 +19,14 @@ void testGetSet(std::string prefix = "") {
     c10d::test::check(store, "key0", "value0");
     c10d::test::check(store, "key1", "value1");
     c10d::test::check(store, "key2", "value2");
+    EXPECT_TRUE(false)
+    // Check compareSet, does not check return value
+    c10d::test::compareSet(
+        store, "key0", "wrongCurrentValue", "newValue");
+    c10d::test::check(store, "key0", "value0");
+    c10d::test::compareSet(store, "key0", "value0", "newValue");
+    c10d::test::check(store, "key0", "newValue");
+
     auto numKeys = store.getNumKeys();
     EXPECT_EQ(numKeys, 3);
     auto delSuccess = store.deleteKey("key0");

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -19,7 +19,7 @@ void testGetSet(std::string prefix = "") {
     c10d::test::check(store, "key0", "value0");
     c10d::test::check(store, "key1", "value1");
     c10d::test::check(store, "key2", "value2");
-    EXPECT_TRUE(false)
+    
     // Check compareSet, does not check return value
     c10d::test::compareSet(
         store, "key0", "wrongCurrentValue", "newValue");


### PR DESCRIPTION
Fixes #{53062}
Replicated the compareSet method and test cases for HashStore and FileStore methods.
